### PR TITLE
Add 'type' prop to allow for number validation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,13 @@ render(<SearchQuery/>);
 
 ## Props
 
+### type
+
+Type: `string`
+Options: `['text', 'number']`
+
+Type of input to accept.
+
 ### value
 
 Type: `string`

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,17 @@ const hasAnsi = require('has-ansi');
 
 const noop = () => {};
 
+const isValid = (value, type) => {
+	switch (type) {
+		case 'number':
+			return /^[1-9](?:[0-9]*)$/.test(String(value));
+		case 'text':
+			return value && value.length > 0;
+		default:
+			return true;
+	}
+};
+
 class TextInput extends Component {
 	constructor(props) {
 		super(props);
@@ -13,8 +24,9 @@ class TextInput extends Component {
 		this.handleKeyPress = this.handleKeyPress.bind(this);
 	}
 
-	render({value, placeholder}) {
-		const hasValue = value.length > 0;
+	render() {
+		const {value, type, placeholder} = this.props;
+		const hasValue = isValid(value, type);
 
 		return (
 			<Text dim={!hasValue}>
@@ -40,7 +52,7 @@ class TextInput extends Component {
 			return;
 		}
 
-		const {value, onChange, onSubmit} = this.props;
+		const {value, type, onChange, onSubmit} = this.props;
 
 		if (key.name === 'return') {
 			onSubmit(value);
@@ -53,25 +65,36 @@ class TextInput extends Component {
 		}
 
 		if (key.name === 'space' || (key.sequence === ch && /^.*$/.test(ch) && !key.ctrl)) {
-			onChange(value + ch);
+			const newValue = String(value) + ch;
+			if (isValid(newValue, type)) {
+				onChange(newValue);
+			}
 		}
 	}
 }
 
 TextInput.propTypes = {
-	value: PropTypes.string,
-	placeholder: PropTypes.string,
+	value: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.number
+	]),
+	placeholder: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.number
+	]),
 	onChange: PropTypes.func,
 	onSubmit: PropTypes.func,
-	focus: PropTypes.bool
+	focus: PropTypes.bool,
+	type: PropTypes.oneOf(['text', 'number'])
 };
 
 TextInput.defaultProps = {
-	value: '',
+	value: undefined,
 	placeholder: '',
 	onChange: noop,
 	onSubmit: noop,
-	focus: true
+	focus: true,
+	type: 'text'
 };
 
 module.exports = TextInput;

--- a/test.js
+++ b/test.js
@@ -12,6 +12,14 @@ test('display value', t => {
 	t.is(renderToString(<TextInput value="Hello"/>), 'Hello');
 });
 
+test('display number value', t => {
+	t.is(renderToString(<TextInput type="number" value="1234"/>), '1234');
+});
+
+test('display invalid number value', t => {
+	t.is(renderToString(<TextInput type="number" value="Hello"/>), '');
+});
+
 test('display placeholder', t => {
 	t.is(renderToString(<TextInput placeholder="Placeholder"/>), renderToString(<Text dim>Placeholder</Text>));
 });
@@ -92,5 +100,19 @@ test('handle change', t => {
 
 	t.true(onChange.calledOnce);
 	t.deepEqual(onChange.firstCall.args, ['AB']);
+	t.false(onSubmit.called);
+});
+
+test('handle invalid change', t => {
+	const setRef = spy();
+	const onChange = spy();
+	const onSubmit = spy();
+
+	build(<TextInput ref={setRef} type="number" value={1} onChange={onChange} onSubmit={onSubmit}/>);
+
+	const ref = setRef.firstCall.args[0];
+	ref.handleKeyPress('B', {sequence: 'B'});
+
+	t.false(onChange.called);
 	t.false(onSubmit.called);
 });


### PR DESCRIPTION
Add `type` prop allowing either `text` or `number` (defaulting to `text`). This allows the developer to accept only valid number input.