### PR TITLE
Updates Ink and replace renamed components

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"babel-plugin-transform-react-jsx": "^6.24.1",
 		"eslint-config-xo-react": "^0.13.0",
 		"eslint-plugin-react": "^7.1.0",
-		"ink": "^0.2.1",
+		"ink": "^0.5.0",
 		"sinon": "^2.3.6",
 		"xo": "^0.18.2"
 	},

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {h, Text, Component} = require('ink');
+const {h, Color, Component} = require('ink');
 const PropTypes = require('prop-types');
 const hasAnsi = require('has-ansi');
 
@@ -17,9 +17,9 @@ class TextInput extends Component {
 		const hasValue = value.length > 0;
 
 		return (
-			<Text dim={!hasValue}>
+			<Color dim={!hasValue}>
 				{hasValue ? value : placeholder}
-			</Text>
+			</Color>
 		);
 	}
 

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 import EventEmitter from 'events';
 import {spy} from 'sinon';
 import test from 'ava';
-import {h, build, renderToString, render, Text} from 'ink';
+import {h, build, renderToString, render, Color} from 'ink';
 import TextInput from '.';
 
 test('default state', t => {
@@ -13,7 +13,7 @@ test('display value', t => {
 });
 
 test('display placeholder', t => {
-	t.is(renderToString(<TextInput placeholder="Placeholder"/>), renderToString(<Text dim>Placeholder</Text>));
+	t.is(renderToString(<TextInput placeholder="Placeholder"/>), renderToString(<Color dim>Placeholder</Color>));
 });
 
 test.serial('attach keypress listener', t => {


### PR DESCRIPTION
Hello good people of ink-text-input,

`<Text/>` component has been deprecated in favour of more decouple solution.
See vadimdemedes/ink#65 and https://github.com/vadimdemedes/ink/issues/82