### PR TITLE
Fix readme example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ $ npm install ink-text-input
 
 ```jsx
 import React from 'react';
-import {render} from 'ink';
+import {render, Box} from 'ink';
 import TextInput from 'ink-text-input';
 
 class SearchQuery extends React.Component {
@@ -26,7 +26,6 @@ class SearchQuery extends React.Component {
 		};
 
 		this.handleChange = this.handleChange.bind(this);
-		this.handleSubmit = this.handleSubmit.bind(this);
 	}
 
 	render() {


### PR DESCRIPTION
The example was broken because of a missing import, and the constructor trying to bind an unexisting method. I fixed it :)