### PR TITLE
Add support for onSubmit handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 		"ink": "^2.0.0",
 		"ink-testing-library": "^1.0.0",
 		"react": "^16.5.2",
+		"sinon": "^7.2.7",
 		"xo": "*"
 	},
 	"babel": {

--- a/src/index.js
+++ b/src/index.js
@@ -19,14 +19,16 @@ class TextInput extends PureComponent {
 		showCursor: PropTypes.bool,
 		stdin: PropTypes.object.isRequired,
 		setRawMode: PropTypes.func.isRequired,
-		onChange: PropTypes.func.isRequired
+		onChange: PropTypes.func.isRequired,
+		onSubmit: PropTypes.func
 	}
 
 	static defaultProps = {
 		placeholder: '',
 		showCursor: true,
 		focus: true,
-		mask: undefined
+		mask: undefined,
+		onSubmit: undefined
 	};
 
 	state = {
@@ -83,7 +85,7 @@ class TextInput extends PureComponent {
 	}
 
 	handleInput = data => {
-		const {value: originalValue, focus, showCursor, mask} = this.props;
+		const {value: originalValue, focus, showCursor, mask, onChange, onSubmit} = this.props;
 		const {cursorOffset: originalCursorOffset} = this.state;
 
 		if (focus === false) {
@@ -92,7 +94,15 @@ class TextInput extends PureComponent {
 
 		const s = String(data);
 
-		if (s === ARROW_UP || s === ARROW_DOWN || s === ENTER || s === CTRL_C) {
+		if (s === ARROW_UP || s === ARROW_DOWN || s === CTRL_C) {
+			return;
+		}
+
+		if (s === ENTER) {
+			if (onSubmit) {
+				onSubmit(originalValue);
+			}
+
 			return;
 		}
 
@@ -126,7 +136,7 @@ class TextInput extends PureComponent {
 		this.setState({cursorOffset});
 
 		if (value !== originalValue) {
-			this.props.onChange(value);
+			onChange(value);
 		}
 	}
 }

--- a/test.js
+++ b/test.js
@@ -7,6 +7,7 @@ import TextInput from '.';
 const noop = () => {};
 
 const CURSOR = chalk.inverse(' ');
+const ENTER = '\r';
 
 test('default state', t => {
 	const {lastFrame} = render(<TextInput value="" onChange={noop}/>);
@@ -62,4 +63,26 @@ test('ignore input when not in focus', t => {
 	stdin.write('X');
 
 	t.is(frames.length, 1);
+});
+
+test.cb('onSubmit', t => {
+	const StatefulTextInput = () => {
+		const [value, setValue] = useState('');
+
+		return (
+			<TextInput value={value} onChange={setValue} onSubmit={value => {
+				t.is(value, 'X');
+				t.end();
+			}}/>
+		);
+	};
+
+	const {stdin, lastFrame} = render(<StatefulTextInput/>);
+
+	t.is(lastFrame(), CURSOR);
+
+	stdin.write('X');
+	stdin.write(ENTER);
+
+	t.is(lastFrame(), `X${CURSOR}`);
 });

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ import React, {useState} from 'react';
 import test from 'ava';
 import chalk from 'chalk';
 import {render} from 'ink-testing-library';
+import sinon from 'sinon';
 import TextInput from '.';
 
 const noop = () => {};
@@ -65,15 +66,14 @@ test('ignore input when not in focus', t => {
 	t.is(frames.length, 1);
 });
 
-test.cb('onSubmit', t => {
+test('onSubmit', t => {
+	const onSubmit = sinon.spy();
+
 	const StatefulTextInput = () => {
 		const [value, setValue] = useState('');
 
 		return (
-			<TextInput value={value} onChange={setValue} onSubmit={value => {
-				t.is(value, 'X');
-				t.end();
-			}}/>
+			<TextInput value={value} onChange={setValue} onSubmit={onSubmit}/>
 		);
 	};
 
@@ -85,4 +85,6 @@ test.cb('onSubmit', t => {
 	stdin.write(ENTER);
 
 	t.is(lastFrame(), `X${CURSOR}`);
+	t.true(onSubmit.calledWith('X'));
+	t.true(onSubmit.calledOnce);
 });


### PR DESCRIPTION
This will add support for an optional onSubmit handler. Currently the onSubmit handler will only be triggered on ENTER.

Related issue: #16