### PR TITLE
Fix cursor position when initial value is set

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ class TextInput extends PureComponent {
 	};
 
 	state = {
-		cursorOffset: 0
+		cursorOffset: (this.props.value || '').length
 	}
 
 	render() {

--- a/test.js
+++ b/test.js
@@ -22,6 +22,12 @@ test('display value', t => {
 	t.is(lastFrame(), 'Hello');
 });
 
+test('display value with cursor', t => {
+	const {lastFrame} = render(<TextInput value="Hello" onChange={noop}/>);
+
+	t.is(lastFrame(), `Hello${CURSOR}`);
+});
+
 test('display placeholder', t => {
 	const {lastFrame} = render(<TextInput value="" placeholder="Placeholder" onChange={noop}/>);
 


### PR DESCRIPTION
When setting an initial value, the cursor is still at the beginning of the line.

This PR sets the initial cursor offset to the value length, so the cursor is at the end of the input, ready to continue typing.