### PR TITLE
Default seems to be true for showing cursor

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ Text to display when `value` is empty.
 ### showCursor
 
 Type: `boolean`<br>
-Default: `false`
+Default: `true`
 
 Whether to show cursor and allow navigation inside text input with arrow keys.
 


### PR DESCRIPTION
Unless I'm mistaken, the cursor seems to show by default on both controlled and uncontrolled components.