### PR TITLE
Don't use wildcard version specifier in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"@babel/plugin-proposal-class-properties": "^7.1.0",
 		"@babel/preset-react": "^7.0.0",
 		"@types/react": "^16.8.8",
-		"ava": "*",
+		"ava": "^1.3.1",
 		"babel-eslint": "^10.0.1",
 		"eslint-config-xo-react": "^0.17.0",
 		"eslint-plugin-react": "^7.11.1",
@@ -55,7 +55,7 @@
 		"react": "^16.5.2",
 		"sinon": "^7.2.7",
 		"typescript": "^3.3.3333",
-		"xo": "*"
+		"xo": "^0.24.0"
 	},
 	"peerDependencies": {
 		"ink": "^2.0.0",


### PR DESCRIPTION
Since the removal of `yarn.lock` in 943f306e2329196b417c3a8bcb27d6eb454b337a installing the package from a blank directory did fail (I don't know how travis tests pass 🤔)

I added the `ava` and `xo` versions from the `yarn.lock` file