### PR TITLE
Do not print when typing `Tab` or `Shift+Tab`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,8 @@ const ENTER = '\r';
 const CTRL_C = '\x03';
 const BACKSPACE = '\x08';
 const DELETE = '\x7F';
+const TAB = '\t';
+const SHIFT_TAB = '\u001B[Z';
 
 class TextInput extends PureComponent {
 	static propTypes = {
@@ -106,7 +108,7 @@ class TextInput extends PureComponent {
 
 		const s = String(data);
 
-		if (s === ARROW_UP || s === ARROW_DOWN || s === CTRL_C) {
+		if (s === ARROW_UP || s === ARROW_DOWN || s === CTRL_C || s === TAB || s === SHIFT_TAB) {
 			return;
 		}
 

--- a/test.js
+++ b/test.js
@@ -86,15 +86,17 @@ test('ignore input when not in focus', t => {
 });
 
 test('ignore input for Tab and Shift+Tab keys', t => {
-	const StatefulTextInput = () => {
+	const Test = () => {
 		const [value, setValue] = useState('');
 
-		return <TextInput focus={false} value={value} onChange={setValue}/>;
+		return <TextInput value={value} onChange={setValue}/>;
 	};
 
-	const {stdin, frames, lastFrame} = render(<StatefulTextInput/>);
+	const {stdin, frames, lastFrame} = render(<Test/>);
 
-	stdin.write('\n');
+	stdin.write('\t');
+	t.is(lastFrame(), '');
+	stdin.write('\u001B[Z');
 	t.is(lastFrame(), '');
 });
 

--- a/test.js
+++ b/test.js
@@ -84,6 +84,19 @@ test('ignore input when not in focus', t => {
 	t.is(frames.length, 1);
 });
 
+test('ignore input for TAB', t => {
+	const StatefulTextInput = () => {
+		const [value, setValue] = useState('');
+
+		return <TextInput focus={false} value={value} onChange={setValue}/>;
+	};
+
+	const {stdin, frames, lastFrame} = render(<StatefulTextInput/>);
+
+	stdin.write('\n');
+	t.is(lastFrame(), '');
+});
+
 test('onSubmit', t => {
 	const onSubmit = sinon.spy();
 

--- a/test.js
+++ b/test.js
@@ -95,9 +95,9 @@ test('ignore input for Tab and Shift+Tab keys', t => {
 	const {stdin, lastFrame} = render(<Test/>);
 
 	stdin.write('\t');
-	t.is(lastFrame(), '');
+	t.is(lastFrame(), CURSOR);
 	stdin.write('\u001B[Z');
-	t.is(lastFrame(), '');
+	t.is(lastFrame(), CURSOR);
 });
 
 test('onSubmit', t => {

--- a/test.js
+++ b/test.js
@@ -92,7 +92,7 @@ test('ignore input for Tab and Shift+Tab keys', t => {
 		return <TextInput value={value} onChange={setValue}/>;
 	};
 
-	const {stdin, frames, lastFrame} = render(<Test/>);
+	const {stdin, lastFrame} = render(<Test/>);
 
 	stdin.write('\t');
 	t.is(lastFrame(), '');

--- a/test.js
+++ b/test.js
@@ -84,7 +84,7 @@ test('ignore input when not in focus', t => {
 	t.is(frames.length, 1);
 });
 
-test('ignore input for TAB', t => {
+test('ignore input for Tab and Shift+Tab keys', t => {
 	const StatefulTextInput = () => {
 		const [value, setValue] = useState('');
 


### PR DESCRIPTION
In order to prepare https://github.com/vadimdemedes/ink/issues/242 I removed the `TAB` and `SHIFT+TAB` keypress.