### PR TITLE
Don't update state if key.escape

### DIFF
--- a/source/index.tsx
+++ b/source/index.tsx
@@ -121,7 +121,8 @@ const TextInput: FC<Props> = ({
 				key.downArrow ||
 				(key.ctrl && input === 'c') ||
 				key.tab ||
-				(key.shift && key.tab)
+				(key.shift && key.tab) ||
+				key.escape
 			) {
 				return;
 			}


### PR DESCRIPTION
I'm using escape to let the user navigate back to previous CLI screens. This is also possible when the user is typing text into ink-text-input, which tries to update state when escape is pressed, causing an update on an unmounted component.

ps; would there be any reason for not using escape for this purpose? Maybe that doesn't work well on other platforms like windows?