### PR TITLE
Add focus prop to readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,13 @@ Type: `Function`
 
 Function to call when `Enter` is pressed, where first argument is a value of the input.
 
+### focus
+
+Type: `boolean`\
+Default: `true`
+
+If `true`, listen to user's input. Useful in case there are multiple input components at the same time and input must be "routed" to a specific component.
+
 ## Uncontrolled usage
 
 This component also exposes an [uncontrolled](https://reactjs.org/docs/uncontrolled-components.html) version, which handles `value` changes for you. To receive the final input value, use `onSubmit` prop.


### PR DESCRIPTION
Thank you so much for providing us with `ink`! I absolutely love it.

The `focus` prop, although a valid prop for the text input, isn't documented anywhere, so I thought I'd add it to the readme.
