### PR TITLE
Update peer dependencies to allow React 17.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,14 +55,14 @@
 		"ink-testing-library": "^2.0.0",
 		"prettier": "^2.0.5",
 		"pretty-quick": "^2.0.1",
-		"react": "^16.5.2",
+		"react": "^17.0.0",
 		"sinon": "^7.2.7",
 		"typescript": "^3.9.5",
 		"xo": "^0.32.0"
 	},
 	"peerDependencies": {
 		"ink": "^3.0.0-3",
-		"react": "^16.5.2"
+		"react": "^16.5.2 || ^17.0.0"
 	},
 	"ava": {
 		"babel": {


### PR DESCRIPTION
This fixes peer dependency warnings when working with newer react versions