### PR TITLE
feat: add ignoreFilter prop, doc, and tests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,6 +92,12 @@ Type: `Function`
 
 Function to call when `Enter` is pressed, where first argument is a value of the input.
 
+### ignoreFilter
+
+Type: `Function`
+
+Whether the input listener should not fire if the specified function returns `true`.
+
 ## Uncontrolled usage
 
 This component also exposes an [uncontrolled](https://reactjs.org/docs/uncontrolled-components.html) version, which handles `value` changes for you. To receive the final input value, use `onSubmit` prop.

--- a/source/index.tsx
+++ b/source/index.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useEffect} from 'react';
-import {Text, useInput} from 'ink';
+import {Text, useInput, type Key} from 'ink';
 import chalk from 'chalk';
 import type {Except} from 'type-fest';
 
@@ -44,6 +44,11 @@ export type Props = {
 	 * Function to call when `Enter` is pressed, where first argument is a value of the input.
 	 */
 	readonly onSubmit?: (value: string) => void;
+
+	/**
+	 * Whether the input listener should not fire if the specified function returns `true`.
+	 */
+	readonly ignoreFilter?: (input: string, key: Key) => boolean;
 };
 
 function TextInput({
@@ -55,6 +60,7 @@ function TextInput({
 	showCursor = true,
 	onChange,
 	onSubmit,
+	ignoreFilter = () => false,
 }: Props) {
 	const [state, setState] = useState({
 		cursorOffset: (originalValue || '').length,
@@ -116,6 +122,7 @@ function TextInput({
 	useInput(
 		(input, key) => {
 			if (
+				ignoreFilter(input, key) ||
 				key.upArrow ||
 				key.downArrow ||
 				(key.ctrl && input === 'c') ||

--- a/test/test.tsx
+++ b/test/test.tsx
@@ -247,3 +247,47 @@ test('adjust cursor when text is shorter than last value', async t => {
 	await delay(100);
 	t.is(lastFrame(), `AB${chalk.inverse(' ')}`);
 });
+
+test('do not accept input if ignoreFilter returns true', async t => {
+	function StatefulTextInput() {
+		const [value, setValue] = useState('');
+
+		return (
+			<TextInput
+				ignoreFilter={input => input === 'q'}
+				value={value}
+				onChange={setValue}
+			/>
+		);
+	}
+
+	const {stdin, lastFrame} = render(<StatefulTextInput />);
+
+	t.is(lastFrame(), cursor);
+	await delay(100);
+	stdin.write('X');
+	await delay(100);
+	stdin.write('q');
+	await delay(100);
+	t.is(lastFrame(), `X${cursor}`);
+});
+
+test('do accept input if ignoreFilter returns false', async t => {
+	function StatefulTextInput() {
+		const [value, setValue] = useState('');
+
+		return (
+			<TextInput ignoreFilter={() => false} value={value} onChange={setValue} />
+		);
+	}
+
+	const {stdin, lastFrame} = render(<StatefulTextInput />);
+
+	t.is(lastFrame(), cursor);
+	await delay(100);
+	stdin.write('X');
+	await delay(100);
+	stdin.write('q');
+	await delay(100);
+	t.is(lastFrame(), `Xq${cursor}`);
+});


### PR DESCRIPTION
Hi.

It would be great if we could control whether the input function should proceed based on certain conditions. This PR allows the developer to specify when they want to do that by adding an additional condition to the start of the useInput closure.

Example

```tsx
<TextInput
  ignoreFilter={(input, key) => input === 'q' || key === 'ctrl'}
  value={value}
  onChange={setValue}
/>
```

If the ignoreFilter callback returns true, the useInput closure returns early and nothing happens.